### PR TITLE
feat(nix): mattpocock/skills を nput 経由で .claude/skills/ へ配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# ---- Nix ----
+# nix build の out-link
+result
+result-*
+
+# ---- nput 配置物（devShell の shellHook が nput apply skills で生成）----
+.claude/skills/*

--- a/flake-parts/devshell.nix
+++ b/flake-parts/devshell.nix
@@ -6,7 +6,7 @@ localFlake:
 # where this module was imported.
 _: {
   perSystem =
-    { pkgs, ... }:
+    { inputs', pkgs, ... }:
     {
       devShells = {
         default = pkgs.mkShell {
@@ -21,7 +21,12 @@ _: {
             checkmake
             emmylua-ls
             ts_query_ls
+            # mattpocock/skills を .claude/skills/ へ配置する nput（project mode 用に pin）
+            inputs'.nput.packages.nput
           ];
+          shellHook = ''
+            nput apply skills --no-wait
+          '';
         };
       };
     };

--- a/flake-parts/nput.nix
+++ b/flake-parts/nput.nix
@@ -1,0 +1,56 @@
+# nput（project mode）の配置 config をまとめる flake-parts module。
+# nput の flakeModules.default（flake.nix の imports が読む）を前提に、
+# perSystem.nput.<name> へ manifest を宣言する（root = projectRoot、repo root 配下へ配置）。
+# devShell の shellHook（flake-parts/devshell.nix）が `nput apply <name>` でビルドし、
+# store-symlink 配置する。配置物は都度 .gitignore へ追記する ephemeral。
+#
+# - skills: mattpocock/skills を .claude/skills/<name> へ配置する。
+
+# The importApply argument. Use this to reference things defined locally,
+# as opposed to the flake where this is imported.
+localFlake:
+
+# Regular module arguments; self, inputs, etc all reference the final user flake,
+# where this module was imported.
+{ inputs, ... }:
+let
+  nputLib = inputs.nput.lib;
+
+  # 展開する skill を明示列挙する（mattpocock/skills の skills/ 配下の相対パス）。
+  skillSubpaths = [
+    "engineering/grill-with-docs"
+    "engineering/improve-codebase-architecture"
+    "engineering/prototype"
+    "engineering/setup-matt-pocock-skills"
+    "engineering/tdd"
+    "engineering/to-issues"
+    "engineering/to-prd"
+    "engineering/triage"
+    "productivity/grilling"
+    "productivity/handoff"
+  ];
+
+  # skill ごとに { ".claude/skills/<name>" = entry; } を組む。
+  # target = .claude/skills/<skill 名>、配置元は skills/<category>/<name> の subpath。
+  skillEntries = builtins.listToAttrs (
+    map (p: {
+      name = ".claude/skills/${baseNameOf p}";
+      value = {
+        src = inputs.matt-skills;
+        subpath = "skills/${p}";
+      };
+    }) skillSubpaths
+  );
+in
+{
+  perSystem =
+    { pkgs, ... }:
+    {
+      # perSystem.nput.skills → flake.nput.<system>.skills へ自動転置される（nput flakeModule）。
+      nput.skills = nputLib.mkManifest {
+        inherit pkgs;
+        root = nputLib.projectRoot;
+        entries = skillEntries;
+      };
+    };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -536,6 +536,22 @@
         "type": "github"
       }
     },
+    "matt-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783689299,
+        "narHash": "sha256-gFPkjrujFAoNXYa0ariPKTj/xBoiCTLUo3X20qrTzRE=",
+        "owner": "mattpocock",
+        "repo": "skills",
+        "rev": "391a2701dd948f94f56a39f7533f8eea9a859c87",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mattpocock",
+        "repo": "skills",
+        "type": "github"
+      }
+    },
     "namaka": {
       "inputs": {
         "haumea": [
@@ -1153,6 +1169,7 @@
         "home-manager": "home-manager",
         "llm-agents-nix": "llm-agents-nix",
         "mac-app-util": "mac-app-util",
+        "matt-skills": "matt-skills",
         "neovim-nightly-overlay": "neovim-nightly-overlay",
         "nix-claude-code": "nix-claude-code",
         "nix-darwin": "nix-darwin",

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,12 @@
         treefmt-nix.follows = "treefmt-nix";
       };
     };
+    # Claude Code 用スキル集（mattpocock/skills）。nput の project mode で
+    # .claude/skills/ へ配置するため flake=false。flake.lock が rev を pin する。
+    matt-skills = {
+      url = "github:mattpocock/skills";
+      flake = false;
+    };
   };
 
   nixConfig = {
@@ -98,11 +104,14 @@
           let
             treefmt.default = importApply ./flake-parts/treefmt.nix;
             devshell.default = importApply ./flake-parts/devshell.nix;
+            nput.default = importApply ./flake-parts/nput.nix;
           in
           [
             inputs.treefmt-nix.flakeModule
+            inputs.nput.flakeModules.default
             treefmt.default
             devshell.default
+            nput.default
           ];
         systems = import inputs.systems;
         flake =


### PR DESCRIPTION
## 概要
mattpocock/skills を nput (project mode) 経由でこのリポジトリの `.claude/skills/` へ配置する仕組みを追加する。

## 変更内容
- `flake.nix`: `matt-skills` input(`mattpocock/skills`, `flake = false`)を追加。`imports` に `inputs.nput.flakeModules.default` と新規モジュール `flake-parts/nput.nix` を追加
- `flake-parts/nput.nix`(新規): nput (project mode) の配置 config をまとめるモジュール。mattpocock/skills の10 skill を `.claude/skills/<name>` へ配置する manifest を宣言
- `flake-parts/devshell.nix`: devShell の packages に `inputs'.nput.packages.nput` を追加し、`shellHook` で `nput apply skills --no-wait` を実行
- `.gitignore`(新規): `.claude/skills/*` と `result`/`result-*` を無視

## 変更の背景・理由
`~/src/github.com/yasunori0418/niface` の `dev/flake.nix` + `nput.nix` と同じ配置手法を導入。このリポジトリは root `flake.nix` 自体が flake-parts の devShell を持つため、niface のような別 `dev/` サブ flake は使わず直接 root へ組み込んだ。

## 動作確認
- `nix build .#nput.x86_64-linux.skills` で manifest が期待通りビルドできることを確認
- `nix develop` 内で `nput apply skills --no-wait` を実行し、10 skill が `.claude/skills/` へ symlink 配置されることを確認(検証後に削除済み)
- `nix eval .#devShells.x86_64-linux.default.name` / `nix fmt` で評価・整形を確認

## 影響範囲・注意点
- `.claude/skills/` はリポジトリに配置される ephemeral な symlink で、git 管理外(`.gitignore` 済み)
- devShell に入る(`nix develop` / direnv)たびに `nput apply skills` が実行される

## 関連 Issue / リンク
(該当なし)