### PR TITLE
chore(home-manager): nput の skills 配置を skills/ 階層へ追従

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1581,11 +1581,11 @@
     "yasunori-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1784287421,
-        "narHash": "sha256-YoAsiAv+0ESysKe0MdbRzvRiqtUPp3fkZY+ZBCECFXQ=",
+        "lastModified": 1784306367,
+        "narHash": "sha256-BDK+J/5BuaDLzYZCSeVfSsdpV42NglZh+g52vga4Y7I=",
         "owner": "yasunori0418",
         "repo": "skills",
-        "rev": "e95bcffae2763a672a1b58eecb94676ab57e0499",
+        "rev": "02fb9daa3206736aa408b2c1f982bda846c8d189",
         "type": "github"
       },
       "original": {

--- a/home-manager/nputFileMap.nix
+++ b/home-manager/nputFileMap.nix
@@ -83,18 +83,18 @@ let
   #
   # 配置先 name は常に .claude/hooks/<name>（cchook が参照するパス）で固定し、
   # subpath だけがリポジトリ内の実体パスを指す。upstream の skills 再構成で
-  # 汎用 hook は hooks/<name>、skill 連動 hook は skills/<category>/hooks/<name>
-  # へ分かれたため、<hook 名> = <subpath> の attrset で持つ（keep-sorted が 1 行 =
-  # 1 要素でソートできる形）。
+  # 汎用 hook は hook 単位のプラグイン hooks/<plugin>/hooks/<name>、skill 連動
+  # hook は skills/<category>/hooks/<name> へ分かれたため、<hook 名> = <subpath>
+  # の attrset で持つ（keep-sorted が 1 行 = 1 要素でソートできる形）。
   yasunoriHookSubpaths = {
     # keep-sorted start
-    askuserquestion-guard = "hooks/askuserquestion-guard";
-    askuserquestion-notify = "hooks/askuserquestion-notify";
-    askuserquestion-toggle = "hooks/askuserquestion-toggle";
+    askuserquestion-guard = "hooks/askuserquestion/hooks/askuserquestion-guard";
+    askuserquestion-notify = "hooks/askuserquestion/hooks/askuserquestion-notify";
+    askuserquestion-toggle = "hooks/askuserquestion/hooks/askuserquestion-toggle";
     git-guard = "skills/git/hooks/git-guard";
-    notify-stop = "hooks/notify-stop";
-    sudo-guard = "hooks/sudo-guard";
-    webfetch-github-guard = "hooks/webfetch-github-guard";
+    notify-stop = "hooks/notify-stop-plugin/hooks/notify-stop";
+    sudo-guard = "hooks/sudo-guard-plugin/hooks/sudo-guard";
+    webfetch-github-guard = "hooks/webfetch-github-guard-plugin/hooks/webfetch-github-guard";
     # keep-sorted end
   };
   yasunoriHookEntries = builtins.listToAttrs (

--- a/home-manager/nputFileMap.nix
+++ b/home-manager/nputFileMap.nix
@@ -25,30 +25,30 @@ let
   };
 
   # yasunori0418/skills（flake input）から Claude Code のスキルを ~/.claude/skills/<name> へ
-  # 配置する。リポジトリは <category>/<skill-name> 構成のため subpath を明示列挙する。
+  # 配置する。リポジトリは skills/<category>/<skill-name> 構成のため subpath を明示列挙する。
   # スキルの実体編集は ~/src/github.com/yasunori0418/skills 側で行い、
   # push + `nix flake update yasunori-skills` + switch で反映する。
   yasunoriSkillSubpaths = [
     # keep-sorted start
-    "claude/external-writes"
-    "claude/latency-triage"
-    "claude/response-format"
-    "claude/session-insights"
-    "claude/test-targeted"
-    "claude/tmp-output"
-    "git/commit-flow"
-    "git/diff-review"
-    "git/parallel-worktree"
-    "git/rebase-flow"
-    "git/reset-flow"
-    "github/gh-ci-investigate"
-    "github/gh-fetch"
-    "github/gh-push"
-    "github/pr-create"
-    "nix/nix-cache-check"
-    "nix/nix-devenv"
-    "product/biz-translate"
-    "product/product-spec"
+    "skills/claude/external-writes"
+    "skills/claude/latency-triage"
+    "skills/claude/response-format"
+    "skills/claude/session-insights"
+    "skills/claude/test-targeted"
+    "skills/claude/tmp-output"
+    "skills/git/commit-flow"
+    "skills/git/diff-review"
+    "skills/git/parallel-worktree"
+    "skills/git/rebase-flow"
+    "skills/git/reset-flow"
+    "skills/github/gh-ci-investigate"
+    "skills/github/gh-fetch"
+    "skills/github/gh-push"
+    "skills/github/pr-create"
+    "skills/nix/nix-cache-check"
+    "skills/nix/nix-devenv"
+    "skills/product/biz-translate"
+    "skills/product/product-spec"
     # keep-sorted end
   ];
   yasunoriSkillEntries = builtins.listToAttrs (
@@ -66,40 +66,47 @@ let
   yasunoriAgentEntries = {
     ".claude/agents/diff-reviewer.md" = {
       src = inputs.yasunori-skills;
-      subpath = "git/diff-review/agents/diff-reviewer.md";
+      subpath = "skills/git/diff-review/agents/diff-reviewer.md";
     };
     ".claude/agents/product-researcher.md" = {
       src = inputs.yasunori-skills;
-      subpath = "product/product-spec/agents/product-researcher.md";
+      subpath = "skills/product/product-spec/agents/product-researcher.md";
     };
   };
 
-  # plugin hook スクリプト（yasunori0418/skills の hooks/scripts/<name>/main.sh）を
+  # plugin hook スクリプト（yasunori0418/skills の <subpath>/main.sh）を
   # ~/.claude/hooks/<name>/main.sh へ配置する。このマシンでは skills plugin を
   # ローカル無効にしているため hooks/hooks.json は読まれない。代わりに cchook
   # （~/.config/cchook/config.yaml）がこの配置済みスクリプトを use_stdin で呼ぶ。
   # スクリプトは flake input 由来で実行ビット付き read-only のためそのまま実行可能。
   # 二重管理を避けるため、旧 cchook/scripts 実体は廃止し本エントリを single source とする。
+  #
+  # 配置先 name は常に .claude/hooks/<name>（cchook が参照するパス）で固定し、
+  # subpath だけがリポジトリ内の実体パスを指す。upstream の skills 再構成で
+  # 汎用 hook は hooks/<name>、skill 連動 hook は skills/<category>/hooks/<name>
+  # へ分かれたため、<hook 名> = <subpath> の attrset で持つ（keep-sorted が 1 行 =
+  # 1 要素でソートできる形）。
+  yasunoriHookSubpaths = {
+    # keep-sorted start
+    askuserquestion-guard = "hooks/askuserquestion-guard";
+    askuserquestion-notify = "hooks/askuserquestion-notify";
+    askuserquestion-toggle = "hooks/askuserquestion-toggle";
+    git-guard = "skills/git/hooks/git-guard";
+    notify-stop = "hooks/notify-stop";
+    sudo-guard = "hooks/sudo-guard";
+    webfetch-github-guard = "hooks/webfetch-github-guard";
+    # keep-sorted end
+  };
   yasunoriHookEntries = builtins.listToAttrs (
-    map
-      (hook: {
-        name = ".claude/${hook}";
+    builtins.attrValues (
+      builtins.mapAttrs (hookName: subpath: {
+        name = ".claude/hooks/${hookName}";
         value = {
           src = inputs.yasunori-skills;
-          subpath = hook;
+          inherit subpath;
         };
-      })
-      [
-        # keep-sorted start
-        "hooks/askuserquestion-guard"
-        "hooks/askuserquestion-notify"
-        "hooks/askuserquestion-toggle"
-        "hooks/git-guard"
-        "hooks/notify-stop"
-        "hooks/sudo-guard"
-        "hooks/webfetch-github-guard"
-        # keep-sorted end
-      ]
+      }) yasunoriHookSubpaths
+    )
   );
 in
 {

--- a/home-manager/nputFileMap.nix
+++ b/home-manager/nputFileMap.nix
@@ -30,11 +30,9 @@ let
   # push + `nix flake update yasunori-skills` + switch で反映する。
   yasunoriSkillSubpaths = [
     # keep-sorted start
-    "skills/claude/external-writes"
     "skills/claude/latency-triage"
     "skills/claude/response-format"
     "skills/claude/session-insights"
-    "skills/claude/test-targeted"
     "skills/claude/tmp-output"
     "skills/git/commit-flow"
     "skills/git/diff-review"
@@ -49,6 +47,8 @@ let
     "skills/nix/nix-devenv"
     "skills/product/biz-translate"
     "skills/product/product-spec"
+    "skills/workflow/external-writes"
+    "skills/workflow/test-targeted"
     # keep-sorted end
   ];
   yasunoriSkillEntries = builtins.listToAttrs (


### PR DESCRIPTION
## 概要

`yasunori0418/skills` が公開スキルを `skills/<category>/<skill-name>/` 階層へ再構成し、
カテゴリ別プラグイン化した（skills 側 PR: yasunori0418/skills#4）。これに伴い nput の
配置定義 `home-manager/nputFileMap.nix` の subpath を新レイアウトへ追従させる。

## 変更内容

`home-manager/nputFileMap.nix` の 3 箇所を追従:

- **`yasunoriSkillSubpaths`**: 全 subpath に `skills/` を前置（`git/commit-flow` →
  `skills/git/commit-flow` など）。加えて skills 側で `external-writes`・`test-targeted` が
  claude カテゴリから新カテゴリ workflow へ移動したため、該当 2 件を
  `skills/workflow/*` へ更新。配置先 `~/.claude/skills/<name>` は `baseNameOf` 由来で不変。
- **`yasunoriAgentEntries`**: diff-reviewer / product-researcher の subpath に `skills/` を前置。
- **`yasunoriHookEntries`**: `git-guard` のみ subpath を `skills/git/hooks/git-guard` に変更
  （skills 側で git-skills プラグインへ同居）。残り 6 hook は `hooks/<name>` のまま。配置先
  `~/.claude/hooks/<name>` は不変。keep-sorted が 1 行 = 1 要素でソートできるよう、
  hook リストを `<hook 名> = <subpath>` の attrset（`yasunoriHookSubpaths`）で持つ形へ変更。

## 変更の背景・理由

skills リポジトリのディレクトリ再構成に追従しないと、`nix flake update yasunori-skills`
した時点で nput が旧 subpath（`git/...` など）を解決できず、`~/.claude/` 配下の skills /
agents / hooks 配置が壊れる。

## 動作確認

- `nix fmt home-manager/nputFileMap.nix` — 差分なし（keep-sorted で破損しないことを確認）。
- `nix-instantiate --parse home-manager/nputFileMap.nix` — PARSE OK。

## 影響範囲・注意点

- **本 PR には `flake.lock` の更新を含めていない**。`yasunori-skills` input は
  `github:yasunori0418/skills`（main 追従）で、skills 側の再構成はまだ main にマージ
  されていないため、今 `flake update` すると旧構造の rev を取り込んでしまう。
- **反映（switch）は skills 側が main にマージされてから**行う:
  1. skills PR (yasunori0418/skills#4) を main へマージ
  2. `nix flake update yasunori-skills`（main の新 rev を lock に取り込む）
  3. `home-manager switch`
- 上記のとおり、本 PR を単体で merge しても lock は旧 rev のままなので、その状態で
  switch すると新 subpath が解決できず壊れる。**merge と switch のタイミングに注意**。
- skills が main マージ済みになったら、本ブランチに `flake update` のコミットを追加するか、
  別途 lock 更新 PR を出す。
