### PR TITLE
feat(claude-web): claude-web セッション向けの Home Manager プロファイルを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,15 @@ Claude Code on the webのセッション向けスタンドアロンHome Manager�
 - **egress policyがサードパーティのgithub.comへのアクセスを許可している必要がある**。
   flakeのinputが`github:`スキームのため、`github.com/<owner>/<repo>/archive/*.tar.gz`が
   引けないと入力解決の時点で403になる。既定のclaude-web policyはgithub.comを
-  セッションに紐づいたrepoだけに絞るので、この状態では主flakeを評価できない
-  （cachix系のsubstituterも同様に403。`nix build`はcache.nixos.orgへfallbackする）。
+  セッションに紐づいたrepoだけに絞るので、この状態では主flakeを評価できない。
+  `api.github.com`のrepo系エンドポイントとcodeloadも同じ絞り込みの対象で、
+  tarballの取得経路は残らない。
+- substituterの到達性はセッションによって変わる（cachix系が通るセッションもある）。
+  通る場合はflake inputの多くをcacheから解決できるが、cacheに無いinputは結局
+  github.comを要求するため、評価できない状況は変わらない。
+- `add_repo`は**同一ownerのrepoしか追加できない**。`nput`や`nur-packages`は足せても、
+  それらが依存する`nix-community/nix-unit`のようなサードパーティのinputは足せないので、
+  egress policyの制限に対する回避手段にはならない。
 
 ## 主要コマンド
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,11 @@ Claude Code on the webのセッション向けスタンドアロンHome Manager�
   out-of-store symlinkの起点をそちらへ向ける。
 - imageが`/root/.bashrc`・`/root/.zshrc`を持つため`nput.backup`を有効にして退避・置換する。
 - systemdが無いのでNixは`nix-installer --init none`で入れ、`nix-daemon`はスクリプトが起動する。
-- **egress policyが`github.com`/`api.github.com`を許可している必要がある**
-  （flakeのinputが`github:`のため）。
+- **egress policyがサードパーティのgithub.comへのアクセスを許可している必要がある**。
+  flakeのinputが`github:`スキームのため、`github.com/<owner>/<repo>/archive/*.tar.gz`が
+  引けないと入力解決の時点で403になる。既定のclaude-web policyはgithub.comを
+  セッションに紐づいたrepoだけに絞るので、この状態では主flakeを評価できない
+  （cachix系のsubstituterも同様に403。`nix build`はcache.nixos.orgへfallbackする）。
 
 ## 主要コマンド
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,18 +30,15 @@ Claude Code on the webのセッション向けスタンドアロンHome Manager�
   out-of-store symlinkの起点をそちらへ向ける。
 - imageが`/root/.bashrc`・`/root/.zshrc`を持つため`nput.backup`を有効にして退避・置換する。
 - systemdが無いのでNixは`nix-installer --init none`で入れ、`nix-daemon`はスクリプトが起動する。
-- **egress policyがサードパーティのgithub.comへのアクセスを許可している必要がある**。
-  flakeのinputが`github:`スキームのため、`github.com/<owner>/<repo>/archive/*.tar.gz`が
-  引けないと入力解決の時点で403になる。既定のclaude-web policyはgithub.comを
-  セッションに紐づいたrepoだけに絞るので、この状態では主flakeを評価できない。
-  `api.github.com`のrepo系エンドポイントとcodeloadも同じ絞り込みの対象で、
-  tarballの取得経路は残らない。
-- substituterの到達性はセッションによって変わる（cachix系が通るセッションもある）。
-  通る場合はflake inputの多くをcacheから解決できるが、cacheに無いinputは結局
-  github.comを要求するため、評価できない状況は変わらない。
-- `add_repo`は**同一ownerのrepoしか追加できない**。`nput`や`nur-packages`は足せても、
-  それらが依存する`nix-community/nix-unit`のようなサードパーティのinputは足せないので、
-  egress policyの制限に対する回避手段にはならない。
+- **GitHub proxyは、セッションに紐づいていないrepoのarchive tarballとAPIを403にする**。
+  これは環境のnetwork access levelと独立していて、**Fullにしても変わらない**
+  （`github.com`・`codeload.github.com`はTrustedの既定allowlistに入っているのに403）。
+  flakeのinputは`github:`スキーム＝archive経由なので、素の`nix build`は入力解決で必ず止まる。
+- 回避は`scripts/claude-web-setup.sh`が持つ。git smart-HTTPには同じ制限がかからず、
+  `github:`のtarballを展開したtreeとgitのtreeはNARが一致する（＝store pathが同じ）ため、
+  403で落ちたinputだけgit経由でstoreへ入れて再試行する。substituterから引けるinputは
+  そこへ来ない（実測では9件だけgit経由が必要だった）。
+- `add_repo`は**同一ownerのrepoしか追加できない**ため、この制限の回避手段にはならない。
 
 ## 主要コマンド
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Nix flakesと`flake-parts`を使用したモジュラー設定管理を採用。
 
 ### ディレクトリ構成
 
-- **`/home-manager/`**: クロスプラットフォームのユーザー環境設定（`linux/`、`macos/`）
+- **`/home-manager/`**: クロスプラットフォームのユーザー環境設定（`linux/`、`macos/`、`claude-web/`）
 - **`/nixos/`**: Linuxシステム設定（マシン固有プロファイル）
 - **`/nix-darwin/`**: macOSシステム設定
 - **`/home/`**: 実際のdotfiles（`home-manager/lib/file-map.nix`経由でシンボリックリンク）
@@ -15,8 +15,23 @@ Nix flakesと`flake-parts`を使用したモジュラー設定管理を採用。
 
 ### プラットフォーム固有の注意点
 
-- **ユーザー名**: Linuxでは`yasunori`、macOSでは`taiki.watanabe`
+- **ユーザー名**: Linuxでは`yasunori`、macOSでは`taiki.watanabe`、claude-webでは`root`
 - **Neovim設定**: `home/.config/nvim/`で管理（dpp.vim + Denops構成）
+
+### claude-webプロファイル
+
+Claude Code on the webのセッション向けスタンドアロンHome Manager設定
+（`home-manager/claude-web/`、`homeConfigurations.claude-web`）。
+
+- コンテナは毎セッション破棄されるため、`make claude-web`（=`scripts/claude-web-setup.sh`）を
+  セッション開始ごとに実行する。環境のsetup scriptへ登録するとClaude Code起動前に走る。
+- 配置は`nputFileMap.nix`をlinuxプロファイルと共用し、`dotLocalShare`（treesitter parser）
+  だけ外す。repoは`~/dotfiles`ではなく`/home/user/dotfiles`にcloneされるため、
+  out-of-store symlinkの起点をそちらへ向ける。
+- imageが`/root/.bashrc`・`/root/.zshrc`を持つため`nput.backup`を有効にして退避・置換する。
+- systemdが無いのでNixは`nix-installer --init none`で入れ、`nix-daemon`はスクリプトが起動する。
+- **egress policyが`github.com`/`api.github.com`を許可している必要がある**
+  （flakeのinputが`github:`のため）。
 
 ## 主要コマンド
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,14 @@ Claude Code on the webのセッション向けスタンドアロンHome Manager�
 
 - コンテナは毎セッション破棄されるため、`make claude-web`（=`scripts/claude-web-setup.sh`）を
   セッション開始ごとに実行する。環境のsetup scriptへ登録するとClaude Code起動前に走る。
-- 配置は`nputFileMap.nix`をlinuxプロファイルと共用し、`dotLocalShare`（treesitter parser）
-  だけ外す。repoは`~/dotfiles`ではなく`/home/user/dotfiles`にcloneされるため、
-  out-of-store symlinkの起点をそちらへ向ける。
+- 配置のentriesは`nputEntries.nix`をlinux/macosと共用する。claude-web固有の差は引数2つだけ。
+  `dotfilesDir`はrepoが`~/dotfiles`ではなく`/home/user/dotfiles`にcloneされるため、
+  `commonTargets`はnvimを使わないので`dotLocalShare`（treesitter parser）を外すため。
 - imageが`/root/.bashrc`・`/root/.zshrc`を持つため`nput.backup`を有効にして退避・置換する。
 - systemdが無いのでNixは`nix-installer --init none`で入れ、`nix-daemon`はスクリプトが起動する。
+- cchookのtirith hookは`uv run --python 3.13`で走る。uv管理のpythonが無いとimage同梱の
+  `/usr/bin/python3.13`を拾ってしまうため、setup scriptが`uv python install`で明示的に入れる
+  （python-build-standaloneのrelease pageは403だが、release assetの実体は取得できる）。
 - **GitHub proxyは、セッションに紐づいていないrepoのarchive tarballとAPIを403にする**。
   これは環境のnetwork access levelと独立していて、**Fullにしても変わらない**
   （`github.com`・`codeload.github.com`はTrustedの既定allowlistに入っているのに403）。

--- a/Makefile
+++ b/Makefile
@@ -100,3 +100,6 @@ nput-rollback: ## nput rollback default (roll back to the previous generation)
 ## Environment Setup Tools ##
 nix-install: ## Install nix.
 	@curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+
+claude-web: ## Setup a Claude Code on the web session (nix install + home-manager activate).
+	@./scripts/claude-web-setup.sh

--- a/flake.nix
+++ b/flake.nix
@@ -183,6 +183,12 @@
                   profileName = "macos";
                   system = "aarch64-darwin";
                 });
+                # Claude Code on the web のセッション用（root / HOME=/root・
+                # 適用は scripts/claude-web-setup.sh）。
+                claude-web = homeManagerConfiguration (hmArgs {
+                  profileName = "claude-web";
+                  system = "x86_64-linux";
+                });
               };
 
             darwinConfigurations =

--- a/home-manager/claude-web/default.nix
+++ b/home-manager/claude-web/default.nix
@@ -1,0 +1,57 @@
+/*
+  Claude Code on the web（claude-web）セッション向けのスタンドアロン Home Manager
+  プロファイル。
+
+  linux / macos プロファイルとの違い:
+    - コンテナは毎セッション作り直され、repo は `~/dotfiles` ではなく
+      `/home/user/dotfiles` に clone される。out-of-store symlink の起点はそちらへ向ける。
+    - サンドボックスは root で動く。systemd は無い（→ nix は
+      `nix-installer --init none` で入れ、daemon は setup script が起動する）。
+    - 配置は linux と同じ nputFileMap から取るが、dotLocalShare（treesitter parser）は
+      取らない（→ ./nput.nix）。
+    - 入れるのは配置した設定・skill・hook が実際に exec するものだけ（→ ./packages.nix）。
+
+  適用は `scripts/claude-web-setup.sh`（nix インストール → activationPackage
+  ビルド → activate）。
+*/
+{ inputs, pkgs, ... }:
+{
+  imports =
+    let
+      # claude-web のセッションでは repo がこの位置に clone される。
+      dotfiles = /home/user/dotfiles;
+      homeDir = /${dotfiles}/home;
+      xdgConfigHome = /${homeDir}/.config;
+      packages = ./packages.nix;
+      nput = import ./nput.nix {
+        inherit
+          inputs
+          pkgs
+          homeDir
+          xdgConfigHome
+          ;
+      };
+    in
+    [
+      packages
+      nput
+    ];
+
+  # closure はそのまま毎セッションのダウンロード時間になるので、要らないものを外す。
+  programs = {
+    # 適用は scripts/claude-web-setup.sh が activationPackage を直接叩くので CLI は不要。
+    home-manager.enable = false;
+    # 共通で読み込む nix-index-database の HM モジュールが引くフル DB を止める。
+    nix-index.enable = false;
+  };
+  manual.manpages.enable = false;
+  # 非 NixOS では LOCALE_ARCHIVE 用に glibcLocales（全ロケール・200MB 超）が入る。
+  i18n.glibcLocales = pkgs.glibcLocalesUtf8;
+
+  home = {
+    # claude-web のサンドボックスは root / HOME=/root で動く。
+    username = "root";
+    homeDirectory = "/root";
+    stateVersion = "24.05";
+  };
+}

--- a/home-manager/claude-web/default.nix
+++ b/home-manager/claude-web/default.nix
@@ -18,18 +18,13 @@
 {
   imports =
     let
-      # claude-web のセッションでは repo がこの位置に clone される。
-      dotfiles = /home/user/dotfiles;
-      homeDir = /${dotfiles}/home;
-      xdgConfigHome = /${homeDir}/.config;
       packages = ./packages.nix;
       nput = import ./nput.nix {
-        inherit
-          inputs
-          pkgs
-          homeDir
-          xdgConfigHome
-          ;
+        inherit inputs pkgs;
+        homeDirectory = "/root";
+        # claude-web のセッションでは repo がこの位置に clone される
+        # （homeDirectory の配下ではないので nputEntries の既定値を上書きする）。
+        dotfilesDir = "/home/user/dotfiles";
       };
     in
     [

--- a/home-manager/claude-web/nput.nix
+++ b/home-manager/claude-web/nput.nix
@@ -1,0 +1,60 @@
+{
+  inputs,
+  pkgs,
+  homeDir,
+  xdgConfigHome,
+  ...
+}:
+let
+  inherit (pkgs.lib) pipe;
+  inherit (pkgs.stdenv.hostPlatform) system;
+  myNurPkgs = inputs.yasunori-nur.legacyPackages.${system};
+  inherit (myNurPkgs.lib.attrsets)
+    targetAttrsValue
+    concatOfAttrs
+    ;
+  inherit (inputs.nput.lib) mkOutOfStoreSymlink;
+
+  # nput の src（out-of-store marker）には絶対パス文字列を渡す。homeDir / xdgConfigHome は
+  # nix path 値なので toString で文字列化する（"${path}" 補間と違い store へコピーされない）。
+  nputFileMap = import ../nputFileMap.nix {
+    inherit
+      inputs
+      pkgs
+      mkOutOfStoreSymlink
+      ;
+    homeDir = toString homeDir;
+    xdgConfigHome = toString xdgConfigHome;
+  };
+
+  concatFileMap =
+    targetNames: fileMap:
+    pipe fileMap [
+      (targetAttrsValue targetNames)
+      concatOfAttrs
+    ];
+
+  # nvim を使わないセッションでは treesitter parser が要らないので dotLocalShare は取らない。
+  entries =
+    (concatFileMap [
+      "homeDirectory"
+      "dotConfig"
+    ] nputFileMap)
+    // (concatFileMap [
+      "homeDirectory"
+      "dotConfig"
+    ] nputFileMap.Linux);
+in
+{
+  nput = {
+    enable = true;
+    inherit entries;
+    # image が /root/.bashrc・/root/.zshrc を持っており、そのままだと nput が
+    # conflict で 1 件も配置せず止まる。既存を退避して置き換える。
+    backup = {
+      enable = true;
+      suffix = "claude_web_backup";
+    };
+  };
+  home.packages = [ inputs.nput.packages.${system}.nput ];
+}

--- a/home-manager/claude-web/nput.nix
+++ b/home-manager/claude-web/nput.nix
@@ -1,49 +1,31 @@
 {
   inputs,
   pkgs,
-  homeDir,
-  xdgConfigHome,
+  homeDirectory,
+  dotfilesDir,
   ...
 }:
 let
-  inherit (pkgs.lib) pipe;
   inherit (pkgs.stdenv.hostPlatform) system;
-  myNurPkgs = inputs.yasunori-nur.legacyPackages.${system};
-  inherit (myNurPkgs.lib.attrsets)
-    targetAttrsValue
-    concatOfAttrs
-    ;
-  inherit (inputs.nput.lib) mkOutOfStoreSymlink;
 
-  # nput の src（out-of-store marker）には絶対パス文字列を渡す。homeDir / xdgConfigHome は
-  # nix path 値なので toString で文字列化する（"${path}" 補間と違い store へコピーされない）。
-  nputFileMap = import ../nputFileMap.nix {
+  # entries の組み立ては linux / macos・flake-parts の nput profile と共有する
+  # （../nputEntries.nix）。claude-web 固有の差は引数 2 つで表現する。
+  #
+  #   - dotfilesDir: clone 先が homeDirectory（/root）の配下ではない
+  #   - commonTargets: nvim を使わないので dotLocalShare（treesitter parser）を取らない
+  entries = import ../nputEntries.nix {
     inherit
       inputs
       pkgs
-      mkOutOfStoreSymlink
+      homeDirectory
+      dotfilesDir
       ;
-    homeDir = toString homeDir;
-    xdgConfigHome = toString xdgConfigHome;
-  };
-
-  concatFileMap =
-    targetNames: fileMap:
-    pipe fileMap [
-      (targetAttrsValue targetNames)
-      concatOfAttrs
+    isDarwin = false;
+    commonTargets = [
+      "homeDirectory"
+      "dotConfig"
     ];
-
-  # nvim を使わないセッションでは treesitter parser が要らないので dotLocalShare は取らない。
-  entries =
-    (concatFileMap [
-      "homeDirectory"
-      "dotConfig"
-    ] nputFileMap)
-    // (concatFileMap [
-      "homeDirectory"
-      "dotConfig"
-    ] nputFileMap.Linux);
+  };
 in
 {
   nput = {

--- a/home-manager/claude-web/packages.nix
+++ b/home-manager/claude-web/packages.nix
@@ -6,6 +6,12 @@
   Nix 側から入れる。
 
   ここに足す前に、その設定・skill・hook が本当にそれを exec しているか確認すること。
+
+  gh は入れない。claude-web の GH_TOKEN は policy proxy のプレースホルダで、
+  `gh auth status` は invalid、repo スコープの REST（`repos/.../pulls` 等）と GraphQL
+  （`gh pr view` / `gh pr checks`）はどちらも proxy が 403 を返す。github 系 skill の
+  実行経路（`gh pr create` / `gh pr checks` / `gh run view` / `gh auth git-credential`）が
+  丸ごと機能しないため、GitHub 操作は GitHub MCP に寄せる。
 */
 { inputs, pkgs, ... }:
 let
@@ -17,7 +23,6 @@ in
   ]
   ++ (with pkgs; [
     # keep-sorted start
-    gh # github 系 skill・gh-push の push 経路
     gitMinimal # ほぼ全ての skill / hook の土台。perl/python 依存を落とした版で足りる
     jq # 全 hook が stdin の JSON を読むのに使う
     python312Packages.uv # cchook config が tirith-check.py を uv 経由で回す

--- a/home-manager/claude-web/packages.nix
+++ b/home-manager/claude-web/packages.nix
@@ -1,0 +1,27 @@
+/*
+  claude-web セッションへ入れるツール。
+
+  選定基準は「配置した settings.json / cchook config / skill / hook が実際に exec する
+  binary」だけ。image に同名のものがあっても、開発環境の供給元を dotfiles へ寄せるため
+  Nix 側から入れる。
+
+  ここに足す前に、その設定・skill・hook が本当にそれを exec しているか確認すること。
+*/
+{ inputs, pkgs, ... }:
+let
+  myNurPkgs = inputs.yasunori-nur.packages.${pkgs.stdenv.hostPlatform.system};
+in
+{
+  home.packages = [
+    myNurPkgs.cchook # settings.json の全 hook event の受け口
+  ]
+  ++ (with pkgs; [
+    # keep-sorted start
+    gh # github 系 skill・gh-push の push 経路
+    gitMinimal # ほぼ全ての skill / hook の土台。perl/python 依存を落とした版で足りる
+    jq # 全 hook が stdin の JSON を読むのに使う
+    python312Packages.uv # cchook config が tirith-check.py を uv 経由で回す
+    tirith # settings.json の mcpServers.tirith
+    # keep-sorted end
+  ]);
+}

--- a/home-manager/nputEntries.nix
+++ b/home-manager/nputEntries.nix
@@ -14,6 +14,18 @@
   pkgs,
   homeDirectory,
   isDarwin,
+
+  # repo の位置。既定は homeDirectory 配下だが、claude-web のように clone 先が
+  # homeDirectory の外にあるプロファイルがあるので上書きできるようにしている。
+  dotfilesDir ? "${homeDirectory}/dotfiles",
+
+  # OS 共通で配置する target。nvim を使わないプロファイルは dotLocalShare
+  # （treesitter parser）を落とすなど、プロファイル側で取捨選択する。
+  commonTargets ? [
+    "homeDirectory"
+    "dotConfig"
+    "dotLocalShare"
+  ],
 }:
 let
   inherit (pkgs.lib) pipe;
@@ -26,8 +38,7 @@ let
   inherit (inputs.nput.lib) mkOutOfStoreSymlink;
 
   # nput の src（out-of-store marker）には絶対パス文字列を渡す。
-  dotfiles = "${homeDirectory}/dotfiles";
-  homeDir = "${dotfiles}/home";
+  homeDir = "${dotfilesDir}/home";
   xdgConfigHome = "${homeDir}/.config";
 
   nputFileMap = import ./nputFileMap.nix {
@@ -47,11 +58,7 @@ let
       concatOfAttrs
     ];
 
-  common = concatFileMap [
-    "homeDirectory"
-    "dotConfig"
-    "dotLocalShare"
-  ] nputFileMap;
+  common = concatFileMap commonTargets nputFileMap;
 
   osSpecific =
     if isDarwin then

--- a/scripts/claude-web-setup.sh
+++ b/scripts/claude-web-setup.sh
@@ -5,16 +5,13 @@
 #   1. Nix を multi-user レイアウトでインストール（NixOS/nix-installer）
 #   2. nix-daemon を起動（systemd が無いので自前で上げる）
 #   3. homeConfigurations.claude-web の activationPackage をビルドして activate
+#      （github の archive が塞がれている場合は input を git 経由で事前投入する）
 #
 # コンテナは毎セッション作り直されるため、セッション開始ごとに 1 回流す想定。環境の
 # setup script へ登録しておくと Claude Code の起動前に走るので、配置した
 # ~/.claude/settings.json の hook もそのセッションから有効になる。
 #
 # 前提:
-#   - egress policy がサードパーティ repo の `github.com/<owner>/<repo>/archive/*.tar.gz`
-#     を許可していること。flake の input は `github:` で書かれているため、塞がれている
-#     環境では入力解決の時点で 403 になる。github.com がホストとして通ることとは別で、
-#     既定の claude-web policy はセッションに紐づいた repo だけに絞る。
 #   - root で実行すること（--init none の Nix は root 専用になる）。
 
 set -euo pipefail
@@ -93,14 +90,129 @@ start_daemon() {
     exit 1
 }
 
+# claude-web の GitHub proxy は、セッションに紐づいていない repo の archive tarball と
+# API を 403 にする。これは環境の network access level と独立していて、Full にしても
+# 変わらない。flake の input は `github:` スキーム＝ archive 経由なので、素の
+# `nix build` は入力解決の時点で必ず止まる。
+#
+# 一方 git smart-HTTP には同じ制限がかかっていない。`github:` の tarball を展開した
+# tree と git が返す tree は NAR が一致する（＝ store path が同じ）ため、git 経由で
+# 取って store へ入れておけば、入力解決は archive を叩かずに valid path を見つける。
+#
+# flake.lock から narHash を引き、fixed-output と同じ算出で store path を求めて、
+# git 由来の path と突き合わせる。一致しなければ tree が tarball と異なる
+# （export-ignore / submodule 等）ということなので、黙って進めず失敗させる。
+readonly MAX_PRIME_ROUNDS=60
+
+# nix の式へ値を渡す手段が無いので getEnv で受け渡す（式側の quote を素直に保つ）。
+nix_eval_str() {
+    "${NIX_PROFILE_DIR}/bin/nix" eval --raw --impure --expr "$1"
+}
+
+# 突き合わせは完全一致でよい。403 の URL は flake.lock の owner / repo から
+# そのまま組み立てられるため、lock 側の表記と必ず一致する。
+narhash_of() {
+    SLUG="$1" REV="$2" LOCK_FILE="${DOTFILES_DIR}/flake.lock" nix_eval_str '
+      let
+        lock = builtins.fromJSON (builtins.readFile (builtins.getEnv "LOCK_FILE"));
+        slug = builtins.getEnv "SLUG";
+        rev = builtins.getEnv "REV";
+        hit = builtins.filter (
+          node:
+          let
+            l = node.locked or { };
+          in
+          (l.type or "") == "github"
+          && ((l.owner or "") + "/" + (l.repo or "")) == slug
+          && (l.rev or "") == rev
+        ) (builtins.attrValues lock.nodes);
+      in
+      if hit == [ ] then "" else (builtins.head hit).locked.narHash
+    '
+}
+
+store_path_of() {
+    NAR_HASH="$1" nix_eval_str '
+      (derivation {
+        name = "source";
+        system = "x86_64-linux";
+        builder = "/bin/sh";
+        outputHashMode = "recursive";
+        outputHashAlgo = "sha256";
+        outputHash = builtins.getEnv "NAR_HASH";
+      }).outPath
+    '
+}
+
+prime_input_from_git() {
+    local slug=$1 rev=$2 narhash want got
+
+    narhash=$(narhash_of "${slug}" "${rev}")
+    if [[ -z ${narhash} ]]; then
+        echo "flake.lock に narHash が見つからない: ${slug} ${rev}" >&2
+        return 1
+    fi
+
+    want=$(store_path_of "${narhash}")
+    got=$(SLUG="${slug}" REV="${rev}" nix_eval_str '
+      (builtins.fetchGit {
+        url = "https://github.com/" + builtins.getEnv "SLUG";
+        rev = builtins.getEnv "REV";
+        allRefs = true;
+      }).outPath
+    ')
+
+    if [[ ${got} != "${want}" ]]; then
+        echo "git 由来の tree が tarball と一致しない: ${slug} ${rev}" >&2
+        echo "  want=${want}" >&2
+        echo "  got =${got}" >&2
+        return 1
+    fi
+}
+
+# ビルドし、github archive の 403 で落ちたら該当 input を git 経由で入れて再試行する。
+# 先回りで全部入れると vim/vim のような巨大 repo まで引くので、必要になった分だけ。
+# substituter から引ける input はそもそもここへ来ない。
+build_activation_package() {
+    local err url slug rev out
+    err=$(mktemp)
+
+    for _ in $(seq 1 "${MAX_PRIME_ROUNDS}"); do
+        if out=$(
+            "${NIX_PROFILE_DIR}/bin/nix" build \
+                --no-link --print-out-paths --accept-flake-config \
+                "${DOTFILES_DIR}#homeConfigurations.claude-web.activationPackage" 2>"${err}"
+            ); then
+            rm -f "${err}"
+            printf '%s\n' "${out}"
+            return 0
+        fi
+
+        url=$(grep -o 'https://github.com/[^/]\+/[^/]\+/archive/[0-9a-f]\+\.tar\.gz' "${err}" | head -1)
+        if [[ -z ${url} ]]; then
+            cat "${err}" >&2
+            rm -f "${err}"
+            return 1
+        fi
+
+        slug=${url#https://github.com/}
+        slug=${slug%%/archive/*}
+        rev=${url##*/archive/}
+        rev=${rev%.tar.gz}
+
+        log "input を git 経由で取得する: ${slug}"
+        prime_input_from_git "${slug}" "${rev}" || { rm -f "${err}"; return 1; }
+    done
+
+    echo "input の事前投入が ${MAX_PRIME_ROUNDS} 回を超えた" >&2
+    rm -f "${err}"
+    return 1
+}
+
 activate_home_manager() {
     log "homeConfigurations.claude-web をビルドする"
     local activation_package
-    activation_package=$(
-        "${NIX_PROFILE_DIR}/bin/nix" build \
-            --no-link --print-out-paths --accept-flake-config \
-            "${DOTFILES_DIR}#homeConfigurations.claude-web.activationPackage"
-    )
+    activation_package=$(build_activation_package)
 
     log "activate: ${activation_package}"
     # home-manager の activate は USER を参照する。非ログインシェルでは未設定なので

--- a/scripts/claude-web-setup.sh
+++ b/scripts/claude-web-setup.sh
@@ -27,7 +27,10 @@ readonly DOTFILES_DIR
 # 証明書検証で落ちる。proxy の無い環境では単に存在しないパスとして無視される。
 readonly CCR_CA_BUNDLE="/root/.ccr/ca-bundle.crt"
 
-log() { printf '\033[1;32m==>\033[0m %s\n' "$1"; }
+# 進捗は stderr へ出す。build_activation_package は stdout で store path を返すので、
+# ログが stdout に混ざると `$(build_activation_package)` の結果が汚れて
+# `${activation_package}/activate` が壊れたパスになる。
+log() { printf '\033[1;32m==>\033[0m %s\n' "$1" >&2; }
 
 install_nix() {
     if [[ -x ${NIX_PROFILE_DIR}/bin/nix ]]; then

--- a/scripts/claude-web-setup.sh
+++ b/scripts/claude-web-setup.sh
@@ -217,7 +217,13 @@ activate_home_manager() {
     log "activate: ${activation_package}"
     # home-manager の activate は USER を参照する。非ログインシェルでは未設定なので
     # ここで明示する（未設定だと unbound variable で即死する）。
-    HOME="${HOME:-/root}" USER="${USER:-root}" "${activation_package}/activate"
+    # PATH も渡す。activate は自前の PATH を組み立てるとき、末尾へ
+    # `dirname $(readlink -m $(type -p nix-env))` を継ぎ足して Nix の bin を拾う。
+    # PATH に Nix が無いとこれが空になり、`nix-build: command not found` で落ちる
+    # （その手前に出る readlink / dirname の "missing operand" も同じ原因）。
+    HOME="${HOME:-/root}" USER="${USER:-root}" \
+        PATH="${NIX_PROFILE_DIR}/bin:${PATH}" \
+        "${activation_package}/activate"
 }
 
 # settings.json の hook（`cchook -event <E>`）は Claude Code が直接 spawn する。この

--- a/scripts/claude-web-setup.sh
+++ b/scripts/claude-web-setup.sh
@@ -173,9 +173,15 @@ prime_input_from_git() {
     fi
 }
 
-# ビルドし、github archive の 403 で落ちたら該当 input を git 経由で入れて再試行する。
-# 先回りで全部入れると vim/vim のような巨大 repo まで引くので、必要になった分だけ。
-# substituter から引ける input はそもそもここへ来ない。
+# ビルドし、落ちた原因が復帰可能なら手当てして再試行する。扱うのは 2 つ。
+#
+#   - github archive の 403 → 該当 input を git 経由で入れる。先回りで全部入れると
+#     vim/vim のような巨大 repo まで引くので、必要になった分だけ。substituter から
+#     引ける input はそもそもここへ来ない
+#   - daemon 断 → 起動し直して同じビルドをやり直す。初回セッションは closure を丸ごと
+#     引くのでビルドが長く、その最中に daemon が落ちると 1 回の実行では復帰できない
+#
+# それ以外の失敗は握り潰さず、nix の出力をそのまま出して抜ける。
 build_activation_package() {
     local err url slug rev out
     err=$(mktemp)
@@ -189,6 +195,12 @@ build_activation_package() {
             rm -f "${err}"
             printf '%s\n' "${out}"
             return 0
+        fi
+
+        if grep -q 'cannot connect to socket' "${err}"; then
+            log "ビルド中に nix-daemon が落ちた。起動し直して再試行する"
+            start_daemon
+            continue
         fi
 
         url=$(grep -o 'https://github.com/[^/]\+/[^/]\+/archive/[0-9a-f]\+\.tar\.gz' "${err}" | head -1)

--- a/scripts/claude-web-setup.sh
+++ b/scripts/claude-web-setup.sh
@@ -51,11 +51,22 @@ install_nix() {
     printf 'extra-experimental-features = flakes\n' >>/etc/nix/nix.custom.conf
 }
 
+# socket ファイルは daemon が死んでも残る。存在確認だけで「起動済み」と判断すると、
+# 死んだ daemon を掴んだまま先へ進んでビルドが
+# `cannot connect to socket ...: Connection refused` で落ちる。実際に応答するかで見る。
+daemon_is_alive() {
+    [[ -S ${DAEMON_SOCKET} ]] || return 1
+    "${NIX_PROFILE_DIR}/bin/nix" store info --store daemon >/dev/null 2>&1
+}
+
 start_daemon() {
-    if [[ -S ${DAEMON_SOCKET} ]]; then
+    if daemon_is_alive; then
         log "nix-daemon は起動済み"
         return
     fi
+
+    # 死んだ daemon が残した socket は bind の邪魔になるので先に落とす。
+    rm -f "${DAEMON_SOCKET}"
 
     log "nix-daemon を起動する"
     # daemon が substituter を引くので proxy / CA を明示的に渡す。呼び出し元のシェルが
@@ -72,11 +83,11 @@ start_daemon() {
         "${NIX_PROFILE_DIR}/bin/nix-daemon" >/tmp/nix-daemon.log 2>&1 </dev/null &
 
     for _ in $(seq 1 30); do
-        [[ -S ${DAEMON_SOCKET} ]] && return
+        daemon_is_alive && return
         sleep 1
     done
 
-    echo "nix-daemon の socket が現れない: /tmp/nix-daemon.log を確認すること" >&2
+    echo "nix-daemon が応答しない: /tmp/nix-daemon.log を確認すること" >&2
     exit 1
 }
 

--- a/scripts/claude-web-setup.sh
+++ b/scripts/claude-web-setup.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+# Claude Code on the web のセッションへ、この dotfiles を起点にした開発環境を用意する。
+#
+#   1. Nix を multi-user レイアウトでインストール（NixOS/nix-installer）
+#   2. nix-daemon を起動（systemd が無いので自前で上げる）
+#   3. homeConfigurations.claude-web の activationPackage をビルドして activate
+#
+# コンテナは毎セッション作り直されるため、セッション開始ごとに 1 回流す想定。環境の
+# setup script へ登録しておくと Claude Code の起動前に走るので、配置した
+# ~/.claude/settings.json の hook もそのセッションから有効になる。
+#
+# 前提:
+#   - egress policy が github.com / api.github.com を許可していること。flake の input は
+#     `github:` で書かれているため、塞がれている環境では入力解決の時点で 403 になる。
+#   - root で実行すること（--init none の Nix は root 専用になる）。
+
+set -euo pipefail
+
+readonly NIX_INSTALLER_URL="https://artifacts.nixos.org/nix-installer"
+readonly NIX_PROFILE_DIR="/nix/var/nix/profiles/default"
+readonly DAEMON_SOCKET="/nix/var/nix/daemon-socket/socket"
+
+DOTFILES_DIR="${DOTFILES_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+readonly DOTFILES_DIR
+
+# claude-web の egress は policy proxy を通る。CA を明示しないと Nix の fetch が
+# 証明書検証で落ちる。proxy の無い環境では単に存在しないパスとして無視される。
+readonly CCR_CA_BUNDLE="/root/.ccr/ca-bundle.crt"
+
+log() { printf '\033[1;32m==>\033[0m %s\n' "$1"; }
+
+install_nix() {
+    if [[ -x ${NIX_PROFILE_DIR}/bin/nix ]]; then
+        log "Nix は導入済み: $("${NIX_PROFILE_DIR}/bin/nix" --version)"
+        return
+    fi
+
+    log "Nix をインストールする（multi-user / --init none）"
+    local extra_conf=()
+    if [[ -f ${CCR_CA_BUNDLE} ]]; then
+        extra_conf+=(--extra-conf "ssl-cert-file = ${CCR_CA_BUNDLE}")
+    fi
+
+    # systemd が無いので --init none。daemon は下の start_daemon が起動する。
+    # インストーラ末尾の self-test は daemon 未起動のため WARN を出すが無害。
+    curl -sSfL "${NIX_INSTALLER_URL}" \
+        | sh -s -- install linux --init none --no-confirm "${extra_conf[@]}"
+
+    # インストーラが有効化するのは nix-command のみ。flakes は自前で足す。
+    printf 'extra-experimental-features = flakes\n' >>/etc/nix/nix.custom.conf
+}
+
+start_daemon() {
+    if [[ -S ${DAEMON_SOCKET} ]]; then
+        log "nix-daemon は起動済み"
+        return
+    fi
+
+    log "nix-daemon を起動する"
+    # daemon が substituter を引くので proxy / CA を明示的に渡す。呼び出し元のシェルが
+    # 終わっても生き残るよう setsid で切り離す。
+    # NOTE: proxy の待受ポートはセッション途中で変わることがある。cache.nixos.org へ
+    #       繋がらなくなったら daemon を kill して本スクリプトを再実行すること
+    #       （daemon は起動時の proxy 設定を握り続ける）。
+    setsid nohup env \
+        HTTPS_PROXY="${HTTPS_PROXY:-}" https_proxy="${https_proxy:-}" \
+        NIX_SSL_CERT_FILE="${NIX_SSL_CERT_FILE:-}" \
+        "${NIX_PROFILE_DIR}/bin/nix-daemon" >/tmp/nix-daemon.log 2>&1 </dev/null &
+
+    for _ in $(seq 1 30); do
+        [[ -S ${DAEMON_SOCKET} ]] && return
+        sleep 1
+    done
+
+    echo "nix-daemon の socket が現れない: /tmp/nix-daemon.log を確認すること" >&2
+    exit 1
+}
+
+activate_home_manager() {
+    log "homeConfigurations.claude-web をビルドする"
+    local activation_package
+    activation_package=$(
+        "${NIX_PROFILE_DIR}/bin/nix" build \
+            --no-link --print-out-paths --accept-flake-config \
+            "${DOTFILES_DIR}#homeConfigurations.claude-web.activationPackage"
+    )
+
+    log "activate: ${activation_package}"
+    # home-manager の activate は USER を参照する。非ログインシェルでは未設定なので
+    # ここで明示する（未設定だと unbound variable で即死する）。
+    HOME="${HOME:-/root}" USER="${USER:-root}" "${activation_package}/activate"
+}
+
+# settings.json の hook（`cchook -event <E>`）は Claude Code が直接 spawn する。この
+# プロセスはログインシェルを経由せず profile を読まないため、PATH に
+# ~/.nix-profile/bin が入らず bare な `cchook` が解決できない。既定の PATH に載って
+# いる /usr/local/bin から HM プロファイルの実体へ symlink を張って解決させる。
+link_hook_binaries() {
+    log "hook から見える PATH へ symlink を張る"
+    local name
+    for name in cchook tirith uv; do
+        if [[ -x ${HOME}/.nix-profile/bin/${name} ]]; then
+            ln -sfn "${HOME}/.nix-profile/bin/${name}" "/usr/local/bin/${name}"
+        fi
+    done
+}
+
+main() {
+    if [[ ${EUID} -ne 0 ]]; then
+        echo "root で実行すること（--init none の Nix は root 専用）" >&2
+        exit 1
+    fi
+
+    export NIX_REMOTE=daemon
+    [[ -f ${CCR_CA_BUNDLE} ]] && export NIX_SSL_CERT_FILE="${CCR_CA_BUNDLE}"
+
+    install_nix
+    start_daemon
+    activate_home_manager
+    link_hook_binaries
+
+    log "完了。~/.claude 配下の skills / agents / hooks / settings.json を配置した"
+}
+
+main "$@"

--- a/scripts/claude-web-setup.sh
+++ b/scripts/claude-web-setup.sh
@@ -11,8 +11,10 @@
 # ~/.claude/settings.json の hook もそのセッションから有効になる。
 #
 # 前提:
-#   - egress policy が github.com / api.github.com を許可していること。flake の input は
-#     `github:` で書かれているため、塞がれている環境では入力解決の時点で 403 になる。
+#   - egress policy がサードパーティ repo の `github.com/<owner>/<repo>/archive/*.tar.gz`
+#     を許可していること。flake の input は `github:` で書かれているため、塞がれている
+#     環境では入力解決の時点で 403 になる。github.com がホストとして通ることとは別で、
+#     既定の claude-web policy はセッションに紐づいた repo だけに絞る。
 #   - root で実行すること（--init none の Nix は root 専用になる）。
 
 set -euo pipefail

--- a/scripts/claude-web-setup.sh
+++ b/scripts/claude-web-setup.sh
@@ -60,10 +60,13 @@ start_daemon() {
     log "nix-daemon を起動する"
     # daemon が substituter を引くので proxy / CA を明示的に渡す。呼び出し元のシェルが
     # 終わっても生き残るよう setsid で切り離す。
+    # NIX_REMOTE は必ず外す。main が export した daemon を daemon 自身が受け取ると、
+    # fork したワーカーが自分の socket へ繋ぎ直そうとして即死し、クライアント側は
+    # `read of 32768 bytes: Connection reset by peer` で落ちる。
     # NOTE: proxy の待受ポートはセッション途中で変わることがある。cache.nixos.org へ
     #       繋がらなくなったら daemon を kill して本スクリプトを再実行すること
     #       （daemon は起動時の proxy 設定を握り続ける）。
-    setsid nohup env \
+    setsid nohup env -u NIX_REMOTE \
         HTTPS_PROXY="${HTTPS_PROXY:-}" https_proxy="${https_proxy:-}" \
         NIX_SSL_CERT_FILE="${NIX_SSL_CERT_FILE:-}" \
         "${NIX_PROFILE_DIR}/bin/nix-daemon" >/tmp/nix-daemon.log 2>&1 </dev/null &

--- a/scripts/claude-web-setup.sh
+++ b/scripts/claude-web-setup.sh
@@ -240,6 +240,18 @@ link_hook_binaries() {
     done
 }
 
+# cchook config の tirith hook は `uv run --python 3.13 -- .../tirith-check.py` で走る。
+# uv は自前で管理する python が無いと image 同梱の /usr/bin/python3.13 を拾うため、
+# image がそれを落とすと hook が動かなくなる（python-build-standalone の release page は
+# proxy が 403 にするが、release asset の実体は取得できるので install は通る）。
+# uv 管理の python は image のものより優先されるので、明示的に入れて依存を断つ。
+readonly HOOK_PYTHON_VERSION="3.13" # cchook config の `--python` と一致させること
+
+install_hook_python() {
+    log "tirith hook 用の python ${HOOK_PYTHON_VERSION} を uv で導入する"
+    "${HOME}/.nix-profile/bin/uv" python install "${HOOK_PYTHON_VERSION}"
+}
+
 main() {
     if [[ ${EUID} -ne 0 ]]; then
         echo "root で実行すること（--init none の Nix は root 専用）" >&2
@@ -253,6 +265,7 @@ main() {
     start_daemon
     activate_home_manager
     link_hook_binaries
+    install_hook_python
 
     log "完了。~/.claude 配下の skills / agents / hooks / settings.json を配置した"
 }


### PR DESCRIPTION
## 概要

Claude Code on the web のセッションごとに、この dotfiles を起点にした開発環境を構築できるようにする。
nix のインストールから `homeConfigurations.claude-web` の activate までを `make claude-web` 1 本で流す。

コンテナは毎セッション破棄されるため、環境の setup script へ登録して Claude Code 起動前に走らせる想定。

**claude-web の既定ネットワークポリシー（＝ github.com がセッション添付 repo に絞られる状態）のまま動く。** 環境側の設定変更は要らない（詳細は「input の解決」）。

Closes #340

## 変更内容

| ファイル | 内容 |
| --- | --- |
| `home-manager/claude-web/` | claude-web プロファイル（`default` / `packages` / `nput`） |
| `home-manager/nputEntries.nix` | `dotfilesDir` / `commonTargets` を引数化（既定値は従来と同値） |
| `flake.nix` | `homeConfigurations.claude-web` を追加 |
| `scripts/claude-web-setup.sh`, `Makefile` | `make claude-web` でセッション初期化 |
| `CLAUDE.md` | claude-web プロファイルの説明 |

### 配置

配置の entries は `nputEntries.nix` を linux / macos・flake-parts の nput profile と共用する。claude-web 固有の差は引数 2 つだけ。

- `dotfilesDir` — repo の clone 先が `/home/user/dotfiles` で、`homeDirectory`（`/root`）の配下にない
- `commonTargets` — nvim を使わないので `dotLocalShare`（treesitter parser）を取らない

この 2 つは `nputEntries.nix` が内部で決め打ちしていたので引数へ出した（`dotfilesDir ? "${homeDirectory}/dotfiles"` / `commonTargets ? [ "homeDirectory" "dotConfig" "dotLocalShare" ]`）。既定値が従来の挙動と同値なので、呼び出し元 3 箇所（`home-manager/{linux,macos}/nput.nix`・`flake-parts/nput.nix`）は無改変。

`dotLocalShare` を boolean で切るのではなくリストで受ける。target が増えたときにプロファイル側で選べるので、boolean を足し続ける構造にならない。

`nput.backup` は claude-web 固有。image が `/root/.bashrc` / `/root/.zshrc` を持っており、そのままだと nput が conflict で 1 件も配置せず止まるため、既存を退避して置き換える。

`nputFileMap.nix` と `claudeSettings.nix`（hook を cchook へ集約する構成）は無改変で共用する。

### ツール

配置した設定・skill・hook が実際に exec するものだけを入れる。

- `cchook`（settings.json の全 hook event の受け口）
- `gitMinimal` / `jq`
- `uv`（cchook config が tirith-check.py を uv 経由で回す） / `tirith`（`mcpServers.tirith`）

settings.json の hook は Claude Code が profile 非経由で spawn するため、`cchook` / `tirith` / `uv` を `/usr/local/bin` から見えるようセットアップスクリプトが symlink を張る。

tirith hook は `uv run --python 3.13` で走るが、uv 管理の python が無いと image 同梱の `/usr/bin/python3.13` を拾う。image がそれを落とすと hook が動かなくなるため、セットアップスクリプトが `uv python install` で明示的に入れて依存を切る（python-build-standalone の release page は proxy が 403 にするが、release asset の実体は取得でき install は通る）。

`gh` は入れない。claude-web の `GH_TOKEN` は policy proxy のプレースホルダで `gh auth status` は invalid、repo スコープの REST と GraphQL はどちらも proxy が 403 を返す。github 系 skill の実行経路（`gh pr create` / `gh pr checks` / `gh run view` / `gh auth git-credential`）が丸ごと機能しないため、GitHub 操作は MCP に寄せる。

### input の解決

claude-web の GitHub proxy は、**セッションに紐づいていない repo の archive tarball と API を 403 にする**。これは環境の network access level と独立していて **Full にしても変わらない**（`github.com` と `codeload.github.com` は Trusted の既定 allowlist に入っているのに 403）。flake の input は `github:` スキーム＝ archive 経由なので、素の `nix build` は入力解決の時点で必ず止まる。

一方 **git smart-HTTP には同じ制限がかかっていない**。そして `github:` の tarball を展開した tree と git が返す tree は NAR が一致する（＝ store path が同じ）。よって git 経由で取って store へ入れておけば、入力解決は archive を叩かずに valid path を見つける。

セットアップスクリプトはこれを利用する。ビルドが 403 で落ちたら該当 input だけを git 経由で入れて再試行する。先回りで全部入れると `vim/vim` のような巨大 repo まで引くため、必要になった分だけに絞る。substituter から引ける input はそもそもここへ来ない。

flake.lock の narHash から fixed-output と同じ算出で store path を求め、git 由来の path と突き合わせる。一致しなければ tree が tarball と異なる（export-ignore / submodule 等）ということなので、黙って進めず失敗させる。

同じループで daemon 断からも復帰する。初回セッションは closure を丸ごと引くのでビルドが長く、その最中に `nix-daemon` が落ちると 1 回の実行では復帰できないため。

実測では `activationPackage` のビルドに git 経由が必要だったのは 9 件だけだった（`nix-unit` / `deno-overlay` / `vim-overlay` / `worktrunk` / `crane` / `rust-overlay` / `xremap-flake` / `tirith` / `matt-skills`）。残りは substituter から解決された。

なお `add_repo` は同一 owner の repo しか追加できない（cross-owner は v1 未対応）ため、この制限の回避手段にはならない。

### closure

毎セッション取り直すのでダウンロード時間に直結する。Home Manager CLI・nix-index のフル DB・HM リファレンス manpage を外し、`glibcLocales` は UTF-8 版へ差し替えて **1.0GiB → 592.5MiB**（実測）。

## 検証

claude-web の実セッションで `make claude-web` を通し実行した。

### 通し実行

Nix インストール → `nix-daemon` 起動 → `activationPackage` ビルド → activate → hook symlink → `uv python install` まで完走。再実行しても同じ結果になる（`Python 3.13 is already installed`）。

### 配置

- `.bashrc` / `.zshrc` が `.claude_web_backup` へ退避され、dotfiles 実体への symlink に置き換わる
- skills 46 / hooks 9 / agents 2、`~/.config` 配下 59 件
- `~/.claude/CLAUDE.md`・`output-styles` を配置、`settings.json` は copy（regular file・書き込み可）
- `~/.local/share/nvim`（treesitter parser）は配置されない

### `nputEntries.nix` 引数化の回帰確認

変更前後の `nputEntries.nix` を同じ引数で import して entries を突き合わせた（HM のアサーションもプラットフォームも経由しないので claude-web セッションから検証できる）。

| プロファイル | 結果 |
| --- | --- |
| linux | **IDENTICAL**（entries 141 件） |
| macos | **IDENTICAL**（entries 114 件） |

claude-web の乗せ替えも、`activationPackage` が乗せ替え前と**同一の store path**（`arwj3r42saacm2s9a72wyf6zjqczdj3x-home-manager-generation`）になることを確認した。生成される配置は 1 バイトも変わっていない。

### hook

`cchook` が配置済み hook を実際に起動することを確認した。

- 通常のコマンド → `{"continue": true}`
- `git reset` 相当 → `permissionDecision: "deny"` + 理由

cchook config が参照する hook 実体 9 件はすべて存在・実行可能。`tirith mcp-server` は正常起動。tirith hook は uv 管理の python（3.13.14）で動作し、image 同梱の `/usr/bin/python3.13` を使わない。

検証中に実セッションの Bash 呼び出しが git-guard にブロックされる形でも確認できた。

### lint / format

- `nix fmt -- --fail-on-change` クリーン（0 changed）
- `shellcheck` / `beautysh --check --indent-size 4` / `bash -n` クリーン

### `nix flake check`

入力解決は通り、実際の評価まで到達する。ただし完走はしない。止まるのは NixOS / home-manager 側のアサーションで、**いずれも `main` で再現する既存問題**。

| 対象 | branch | main | 判定 |
| --- | --- | --- | --- |
| `nixosConfigurations.yasunori-laptop` / `laptop2` | OK | — | — |
| `nixosConfigurations.yasunori-desktop` | NVIDIA PRIME assertion | 同じ | 既存問題 |
| `homeConfigurations.claude-web` | drv 取得 + build + activate 成功 | （新規） | OK |
| `homeConfigurations.linux` | `nix.package` assertion | 同じ | 既存問題 |

本 PR が `flake.nix` に加えたのは `homeConfigurations.claude-web` の 6 行のみで `nixosConfigurations` には触れていない。

### 修正した実行時バグ

実際に走らせて初めて踏めたもの。

| コミット | 内容 |
| --- | --- |
| `b8b09f6` | `nix-daemon` が `NIX_REMOTE=daemon` を受け取ると、fork したワーカーが自分の socket へ繋ぎ直そうとして即死する |
| `a4c21e1` | daemon の生存判定が socket ファイルの有無だけだったため、死んだ daemon を掴んだまま進み `Connection refused` で落ちる（unix socket はプロセスが死んでも残る） |
| `3051682` | activate へ Nix の PATH を渡しておらず、activate 内の `type -p nix-env` からの PATH 継ぎ足しが空になって `nix-build: command not found` で落ちる |
| `d1212c5` | 進捗ログが stdout に出ており、`$(build_activation_package)` の戻り値にログ行が混ざる。input の事前投入が発生する実行では `${activation_package}/activate` が壊れたパスになる |

## 残タスク

- 環境の setup script へ `make claude-web` を登録（Web UI 側の作業。repo からは変えられない）
- （本 PR 外）`nixosConfigurations.yasunori-desktop` と `homeConfigurations.linux` のアサーション。`main` から存在しており `nix flake check` が通らない原因になっている