### PR TITLE
feat(home-manager): nput の home 配置を flake-parts プロファイル化し make から実行可能にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,3 +27,33 @@ make nix-darwin     # nix-darwin rebuild switch
 nix fmt             # コードフォーマット（treefmt管理）
 make help           # 全コマンド一覧
 ```
+
+## nput による設定ファイル配置
+
+`~/.claude/*`・`~/.config/*` などの配置は home-manager の `home.file` ではなく
+[nput](https://github.com/yasunori0418/nput) が行う（home-manager にはモジュールとして
+import され、`home.activation` から起動される）。
+
+entries の定義は `home-manager/nputEntries.nix` に集約し、以下 2 経路が共有する。
+
+- **home-manager 経由**: `home-manager/{linux,macos}/nput.nix` → switch 時に activation から適用
+- **flake-parts 経由**: `flake-parts/nput.nix` の `nput.default` → `nput` CLI から直接適用
+
+両者は同じ entries から同一の manifest を生成し、同じ generation profile
+（`<state>/nix/profiles/nput/default`）を共有する。よって switch を挟まずに
+CLI から配置を反映できる。
+
+```bash
+make nput-dryrun      # 配置差分のプレビュー（副作用なし）
+make nput-apply       # 配置を適用（home-manager switch 不要）
+make nput-recopy      # copy 配置（~/.claude/settings.json）を再配置
+make nput-skills      # project mode: .claude/skills/ へ配置
+make nput-generations # 世代一覧
+make nput-rollback    # 直前の世代へロールバック
+```
+
+`~/.claude/settings.json` は `home-manager/claudeSettings.nix` から生成した JSON を
+`method = "copy"` で配置する（Claude Code の TUI が書き戻せるようにするため）。
+copy は place-once なので switch では追従せず、Nix 側の変更を反映するには
+`make nput-recopy` が要る。逆に TUI が書き戻した内容は recopy で失われるため、
+恒久化したい変更は `claudeSettings.nix` へ戻す（SSOT は Nix 側）。

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,30 @@ nix-rebuild: ## nixos or nix-darwin rebuild switch
 nixos-generate: ## nixos-generator
 	@nix run 'nixpkgs#nixos-generators' -- --flake '.#iso' -f iso | xargs -I{} ln -svf {} ./
 
+## nput placement commands ##
+# nput.default（home mode）は home-manager の activation と同じ profile 名 `default`
+# を共有する。よって switch を挟まずに CLI から配置を反映できる。
+nput-apply: ## nput apply default (home mode placement without home-manager switch)
+	@nput apply default --verbose
+
+nput-recopy: ## nput apply default --recopy (re-copy copy targets e.g. ~/.claude/settings.json)
+	@nput apply default --recopy --verbose
+
+nput-dryrun: ## nput apply default --dryrun (preview placement, no side effects)
+	@nput apply default --dryrun --verbose
+
+nput-skills: ## nput apply skills (project mode placement into .claude/skills)
+	@nput apply skills --verbose
+
+nput-gitignore: ## nput gitignore --all (print project mode placement targets)
+	@nput gitignore --all
+
+nput-generations: ## nput list-generations default
+	@nput list-generations default
+
+nput-rollback: ## nput rollback default (roll back to the previous generation)
+	@nput rollback default --verbose
+
 ## Environment Setup Tools ##
 nix-install: ## Install nix.
 	@curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install

--- a/flake-parts/nput.nix
+++ b/flake-parts/nput.nix
@@ -1,10 +1,23 @@
-# nput（project mode）の配置 config をまとめる flake-parts module。
+# nput の配置 config をまとめる flake-parts module。
 # nput の flakeModules.default（flake.nix の imports が読む）を前提に、
-# perSystem.nput.<name> へ manifest を宣言する（root = projectRoot、repo root 配下へ配置）。
-# devShell の shellHook（flake-parts/devshell.nix）が `nput apply <name>` でビルドし、
-# store-symlink 配置する。配置物は都度 .gitignore へ追記する ephemeral。
+# perSystem.nput.<name> へ manifest を宣言する。宣言したものは
+# flake.nput.<system>.<name> へ転置され、`nput apply <name>` から直接叩ける。
 #
-# - skills: mattpocock/skills を .claude/skills/<name> へ配置する。
+# - default: home mode（root = homeRoot）。~/.claude/* や ~/.config/* の配置。
+#   entries は home-manager 側（home-manager/{linux,macos}/nput.nix）と
+#   ../home-manager/nputEntries.nix を共有するので内容は完全に一致する。
+#   名前を `default` にしているのは HM モジュールの activation
+#   （`nput apply --manifest <path>`・位置引数なし = profile 名 `default`）と
+#   同じ generation profile（<state>/nix/profiles/nput/default）へ載せるため。
+#   別名にすると CLI 適用と HM activation が別 profile になり、同じ配置先を
+#   互いに奪い合って stale 削除が壊れる。
+#   これにより `nput apply --recopy`（settings.json の copy 再配置）が
+#   home-manager switch を挟まずに Makefile から叩ける。
+#
+# - skills: project mode（root = projectRoot）。mattpocock/skills を
+#   .claude/skills/<name> へ配置する。devShell の shellHook
+#   （flake-parts/devshell.nix）が `nput apply skills` でビルド・配置する。
+#   配置物は .gitignore 済みの ephemeral。
 
 # The importApply argument. Use this to reference things defined locally,
 # as opposed to the flake where this is imported.
@@ -15,6 +28,14 @@ localFlake:
 { inputs, ... }:
 let
   nputLib = inputs.nput.lib;
+
+  # home mode の entries は out-of-store symlink の src に $HOME の絶対パスを
+  # 埋めるため、system ごとにユーザー名 / home ディレクトリを解決する。
+  # 値は home-manager/{linux,macos}/default.nix の home.username /
+  # home.homeDirectory と一致させること（ズレると配置先が食い違う）。
+  homeDirectoryFor =
+    system: if isDarwinSystem system then "/Users/taiki.watanabe" else "/home/yasunori";
+  isDarwinSystem = system: builtins.match ".*-darwin" system != null;
 
   # 展開する skill を明示列挙する（mattpocock/skills の skills/ 配下の相対パス）。
   skillSubpaths = [
@@ -44,13 +65,25 @@ let
 in
 {
   perSystem =
-    { pkgs, ... }:
+    { pkgs, system, ... }:
     {
-      # perSystem.nput.skills → flake.nput.<system>.skills へ自動転置される（nput flakeModule）。
-      nput.skills = nputLib.mkManifest {
-        inherit pkgs;
-        root = nputLib.projectRoot;
-        entries = skillEntries;
+      # perSystem.nput.<name> → flake.nput.<system>.<name> へ自動転置される（nput flakeModule）。
+      nput = {
+        default = nputLib.mkManifest {
+          inherit pkgs;
+          root = nputLib.homeRoot;
+          entries = import ../home-manager/nputEntries.nix {
+            inherit inputs pkgs;
+            homeDirectory = homeDirectoryFor system;
+            isDarwin = isDarwinSystem system;
+          };
+        };
+
+        skills = nputLib.mkManifest {
+          inherit pkgs;
+          root = nputLib.projectRoot;
+          entries = skillEntries;
+        };
       };
     };
 }

--- a/flake-parts/nput.nix
+++ b/flake-parts/nput.nix
@@ -33,9 +33,7 @@ let
   # 埋めるため、system ごとにユーザー名 / home ディレクトリを解決する。
   # 値は home-manager/{linux,macos}/default.nix の home.username /
   # home.homeDirectory と一致させること（ズレると配置先が食い違う）。
-  homeDirectoryFor =
-    system: if isDarwinSystem system then "/Users/taiki.watanabe" else "/home/yasunori";
-  isDarwinSystem = system: builtins.match ".*-darwin" system != null;
+  homeDirectoryFor = isDarwin: if isDarwin then "/Users/taiki.watanabe" else "/home/yasunori";
 
   # 展開する skill を明示列挙する（mattpocock/skills の skills/ 配下の相対パス）。
   skillSubpaths = [
@@ -65,7 +63,10 @@ let
 in
 {
   perSystem =
-    { pkgs, system, ... }:
+    { pkgs, ... }:
+    let
+      inherit (pkgs.stdenv.hostPlatform) isDarwin;
+    in
     {
       # perSystem.nput.<name> → flake.nput.<system>.<name> へ自動転置される（nput flakeModule）。
       nput = {
@@ -73,9 +74,8 @@ in
           inherit pkgs;
           root = nputLib.homeRoot;
           entries = import ../home-manager/nputEntries.nix {
-            inherit inputs pkgs;
-            homeDirectory = homeDirectoryFor system;
-            isDarwin = isDarwinSystem system;
+            inherit inputs pkgs isDarwin;
+            homeDirectory = homeDirectoryFor isDarwin;
           };
         };
 

--- a/home-manager/linux/default.nix
+++ b/home-manager/linux/default.nix
@@ -7,17 +7,13 @@
 {
   imports =
     let
-      dotfiles = /${config.home.homeDirectory}/dotfiles;
-      homeDir = /${dotfiles}/home;
-      xdgConfigHome = /${homeDir}/.config;
       packages = ./packages.nix;
       nput = import ./nput.nix {
         inherit
           inputs
           pkgs
-          homeDir
-          xdgConfigHome
           ;
+        inherit (config.home) homeDirectory;
       };
       clearDppStateAfterLinkGeneration = ../clear-dpp-state-after-link-generation.nix;
       programs = [

--- a/home-manager/linux/nput.nix
+++ b/home-manager/linux/nput.nix
@@ -1,49 +1,19 @@
 {
   inputs,
   pkgs,
-  homeDir,
-  xdgConfigHome,
+  homeDirectory,
   ...
 }:
 let
-  inherit (pkgs.lib) pipe;
   inherit (pkgs.stdenv.hostPlatform) system;
-  myNurPkgs = inputs.yasunori-nur.legacyPackages.${system};
-  inherit (myNurPkgs.lib.attrsets)
-    targetAttrsValue
-    concatOfAttrs
-    ;
-  inherit (inputs.nput.lib) mkOutOfStoreSymlink;
 
-  # nput の src（out-of-store marker）には絶対パス文字列を渡す。homeDir / xdgConfigHome は
-  # nix path 値なので toString で文字列化する（"${path}" 補間と違い store へコピーされない）。
-  nputFileMap = import ../nputFileMap.nix {
-    inherit
-      inputs
-      pkgs
-      mkOutOfStoreSymlink
-      ;
-    homeDir = toString homeDir;
-    xdgConfigHome = toString xdgConfigHome;
+  # entries の組み立ては flake-parts の nput profile と共有する
+  # （../nputEntries.nix・同じ entries から HM activation 用 manifest と
+  # flake output `nput.<system>.default` が生成される）。
+  entries = import ../nputEntries.nix {
+    inherit inputs pkgs homeDirectory;
+    isDarwin = false;
   };
-
-  concatFileMap =
-    targetNames: fileMap:
-    pipe fileMap [
-      (targetAttrsValue targetNames)
-      concatOfAttrs
-    ];
-
-  entries =
-    (concatFileMap [
-      "homeDirectory"
-      "dotConfig"
-      "dotLocalShare"
-    ] nputFileMap)
-    // (concatFileMap [
-      "homeDirectory"
-      "dotConfig"
-    ] nputFileMap.Linux);
 in
 {
   nput = {

--- a/home-manager/macos/default.nix
+++ b/home-manager/macos/default.nix
@@ -7,9 +7,6 @@
 {
   imports =
     let
-      dotfiles = /${config.home.homeDirectory}/dotfiles;
-      homeDir = /${dotfiles}/home;
-      xdgConfigHome = /${homeDir}/.config;
       packages = ./packages.nix;
       clearDppStateAfterLinkGeneration = ../clear-dpp-state-after-link-generation.nix;
       launchd = [
@@ -23,9 +20,8 @@
         inherit
           inputs
           pkgs
-          homeDir
-          xdgConfigHome
           ;
+        inherit (config.home) homeDirectory;
       };
     in
     [

--- a/home-manager/macos/nput.nix
+++ b/home-manager/macos/nput.nix
@@ -1,50 +1,19 @@
 {
   inputs,
   pkgs,
-  homeDir,
-  xdgConfigHome,
+  homeDirectory,
   ...
 }:
 let
-  inherit (pkgs.lib) pipe;
   inherit (pkgs.stdenv.hostPlatform) system;
-  myNurPkgs = inputs.yasunori-nur.legacyPackages.${system};
-  inherit (myNurPkgs.lib.attrsets)
-    targetAttrsValue
-    concatOfAttrs
-    ;
-  inherit (inputs.nput.lib) mkOutOfStoreSymlink;
 
-  # nput の src（out-of-store marker）には絶対パス文字列を渡す。homeDir / xdgConfigHome は
-  # nix path 値なので toString で文字列化する（"${path}" 補間と違い store へコピーされない）。
-  nputFileMap = import ../nputFileMap.nix {
-    inherit
-      inputs
-      pkgs
-      mkOutOfStoreSymlink
-      ;
-    homeDir = toString homeDir;
-    xdgConfigHome = toString xdgConfigHome;
+  # entries の組み立ては flake-parts の nput profile と共有する
+  # （../nputEntries.nix・同じ entries から HM activation 用 manifest と
+  # flake output `nput.<system>.default` が生成される）。
+  entries = import ../nputEntries.nix {
+    inherit inputs pkgs homeDirectory;
+    isDarwin = true;
   };
-
-  concatFileMap =
-    targetNames: fileMap:
-    pipe fileMap [
-      (targetAttrsValue targetNames)
-      concatOfAttrs
-    ];
-
-  entries =
-    (concatFileMap [
-      "homeDirectory"
-      "dotConfig"
-      "dotLocalShare"
-    ] nputFileMap)
-    // (concatFileMap [
-      "homeDirectory"
-      "dotConfig"
-      "library"
-    ] nputFileMap.MacOS);
 in
 {
   nput = {

--- a/home-manager/nputEntries.nix
+++ b/home-manager/nputEntries.nix
@@ -1,0 +1,69 @@
+# nput の home mode（root = homeRoot）entries を組み立てる共有モジュール。
+#
+# home-manager モジュール（home-manager/{linux,macos}/nput.nix）と flake-parts の
+# nput profile（flake-parts/nput.nix）の両方から import される。HM の `config` に
+# 依存しないよう、homeDirectory は呼び出し側が絶対パス文字列で渡す
+# （HM 側は config.home.homeDirectory、flake-parts 側は flake-parts/nput.nix の
+# 定義値を渡す。両者が食い違うと配置先がズレるので値は一致させること）。
+#
+# entries そのものは root 非依存（root は mkManifest / HM モジュールが homeRoot に
+# pin する）ため、同じ entries から HM activation 用の manifest と CLI 用の
+# flake output `nput.<system>.default` が同一内容で生成される。
+{
+  inputs,
+  pkgs,
+  homeDirectory,
+  isDarwin,
+}:
+let
+  inherit (pkgs.lib) pipe;
+  inherit (pkgs.stdenv.hostPlatform) system;
+  myNurPkgs = inputs.yasunori-nur.legacyPackages.${system};
+  inherit (myNurPkgs.lib.attrsets)
+    targetAttrsValue
+    concatOfAttrs
+    ;
+  inherit (inputs.nput.lib) mkOutOfStoreSymlink;
+
+  # nput の src（out-of-store marker）には絶対パス文字列を渡す。
+  dotfiles = "${homeDirectory}/dotfiles";
+  homeDir = "${dotfiles}/home";
+  xdgConfigHome = "${homeDir}/.config";
+
+  nputFileMap = import ./nputFileMap.nix {
+    inherit
+      inputs
+      pkgs
+      mkOutOfStoreSymlink
+      homeDir
+      xdgConfigHome
+      ;
+  };
+
+  concatFileMap =
+    targetNames: fileMap:
+    pipe fileMap [
+      (targetAttrsValue targetNames)
+      concatOfAttrs
+    ];
+
+  common = concatFileMap [
+    "homeDirectory"
+    "dotConfig"
+    "dotLocalShare"
+  ] nputFileMap;
+
+  osSpecific =
+    if isDarwin then
+      concatFileMap [
+        "homeDirectory"
+        "dotConfig"
+        "library"
+      ] nputFileMap.MacOS
+    else
+      concatFileMap [
+        "homeDirectory"
+        "dotConfig"
+      ] nputFileMap.Linux;
+in
+common // osSpecific


### PR DESCRIPTION
## 概要

nput の home 配置（`~/.claude/*`・`~/.config/*`）を flake-parts の `nput.default` として公開し、home-manager switch を挟まずに `make` 経由で nput を直接叩けるようにする。

## 変更内容

- **`home-manager/nputEntries.nix`（新規）**: `linux/nput.nix` と `macos/nput.nix` にほぼ同一のコピーとして存在した entries 組み立てロジックを集約。flake-parts 側からも参照できるよう home-manager の `config` へ依存しない形にし、`homeDirectory`（絶対パス文字列）と `isDarwin` を引数で受け取る
- **`flake-parts/nput.nix`**: `perSystem.nput.default`（`root = homeRoot`）を追加。既存の `nput.skills`（project mode）と並列に宣言し、`flake.nput.<system>.default` へ転置される
- **`Makefile`**: `nput-apply` / `nput-recopy` / `nput-dryrun` / `nput-skills` / `nput-gitignore` / `nput-generations` / `nput-rollback` の 7 ターゲットを追加
- **`CLAUDE.md`**: nput による配置の節を追加

## 変更の背景・理由

これまで home 配置は home-manager の `home.activation` 経由でしか適用できず、nput CLI から直接叩ける flake output が存在しなかった。

そのため `~/.claude/settings.json` の運用に支障があった。この設定は Claude Code の TUI が書き戻せるよう `method = "copy"` で配置しているが、copy は place-once のため switch では追従しない。Nix 側の変更を反映するには `nput apply --recopy` が必要だが、**その entry point 自体が無かった**ため、ドキュメントに書かれていた recopy 運用が実際には実行できない状態だった。

### profile 名を `default` にした理由

nput の home-manager モジュールは activation から `nput apply --manifest <path>` を**位置引数なし**で呼ぶ。位置引数なし = profile 名 `default` のため、activation 側は `<state>/nix/profiles/nput/default` に載っている。

flake-parts 側を別名（例 `home`）にすると、**同じ配置先を 2 つの独立した generation profile が奪い合い、互いの配置を stale とみなして削除し合う**。これを避けるため名前を `default` に揃えている。

## 動作確認

- **manifest の同一性**: `nix build .#nput.x86_64-linux.default` の結果と、NixOS 埋め込み home-manager が activation で呼ぶ manifest が同一 store path（`qqym1nhxnw69bcinryw0n7q2xhrx7sh3-nput-manifest`）であることを確認。両経路が同じ内容へ収束する
- `make nput-dryrun`: 139 entries すべて `replace`、conflict / remove ゼロ、exit 0
- `make nput-apply`: 既存 generation 27 のまま新世代を作らない（内容不変のため）＝意図通り
- `make nput-recopy`: `recopied .claude/settings.json` を確認。ファイルは `-rw-r--r--` のままで copy semantics を維持
- 配置物の健全性: `~/.claude/CLAUDE.md` は dotfiles 実体への symlink、`settings.json` は書き込み可能な実ファイルのまま
- `x86_64-linux` / `aarch64-darwin` 両方で eval 成功。`nix fmt` 通過、`make help` の描画も確認

## 影響範囲・注意点

- entries の内容は変更していないため、既存の配置結果に差分は出ない（dryrun で全件 `replace`・conflict ゼロを確認済み）
- `flake-parts/nput.nix` の `homeDirectoryFor` は home ディレクトリをリテラルで持つ。`home-manager/{linux,macos}/default.nix` の `home.homeDirectory` と一致させる必要があり、ズレると配置先が食い違う（コメントに明記済み）
- **既知の未対応事項（本 PR 以前から存在）**: `nix build .#homeConfigurations.linux.activationPackage` は `nix.package must be specified for generating nix.conf` のアサーションで失敗する。本変更をローカルへ stash した未変更コードでも再現するため本 PR とは無関係。実際に使用される NixOS 埋め込み home-manager 経路は正常にビルド・eval できている。スタンドアロン home-manager 経路を使う場合は別途対処が必要
